### PR TITLE
Upgrade to Prestashop latest API

### DIFF
--- a/lib/presta_shop/headers.rb
+++ b/lib/presta_shop/headers.rb
@@ -3,7 +3,7 @@ require "rubygems/version"
 module PrestaShop
     class Headers
         MIN_COMPATIBLE_VERSION = Gem::Version.new("1.5.0.0")
-          MAX_COMPATIBLE_VERSION = Gem::Version.new("1.5.6.0")
+          MAX_COMPATIBLE_VERSION = Gem::Version.new("1.6.0.8")
 
           attr_reader :version
 

--- a/lib/presta_shop/resources.rb
+++ b/lib/presta_shop/resources.rb
@@ -32,6 +32,7 @@ module PrestaShop
                     manufacturers
                     order_carriers
                     order_details
+                    order_slip
                     order_discounts
                     order_histories
                     order_invoices
@@ -70,6 +71,6 @@ module PrestaShop
                     warehouse_product_locations
                     warehouses
                     weight_ranges
-                    zones 
+                    zones
     }
 end


### PR DESCRIPTION
I checked this gem some time ago and found some issues with current API fixed all 
1. First change header.rb file to latest version of gem.
2. In scraping the resources one other resource is added in 1.6 i.e order_slip that causes some issue when resource found is not available in resource.rb .
